### PR TITLE
Change to Gauss-Bessel kernel

### DIFF
--- a/cygrid/kernels.pyx
+++ b/cygrid/kernels.pyx
@@ -163,11 +163,12 @@ cdef double tapered_sinc_1d_kernel(
 
     return sinc(arg / kernel_params[2]) * exp(-(arg / kernel_params[1]) ** 2)
 
+
 cdef double gauss_bessel_kernel(
         double distance, double bearing, double[::1] kernel_params
         ) nogil:
     '''
-    Gauss-Bessel-1D kernel function.
+    Gauss-Bessel kernel function.
 
     Parameters
     ----------
@@ -175,17 +176,22 @@ cdef double gauss_bessel_kernel(
     kernel_params : double[::1]
         mem-view on kernel-parameters array
         must contain:
-        kernel_params[0] : Bessel width
-        kernel_params[1] : Gaussian sigma
+        kernel_params[0] : Beam width
+        kernel_params[1] : 2.52 - Mangum et al. optimization.
+        kernel_params[2] : 1.55
+
+    Returns
+    -------
+    Kernel weight : double
     '''
 
     cdef:
         double arg, Earg, gauss, bessel
 
-    arg = PI * fabs(distance) / kernel_params[0]
+    arg = PI * fabs(distance) / kernel_params[0] / kernel_params[2]
     bessel = csc.j1(arg) / arg
 
-    Earg = distance * distance / kernel_params[1] / kernel_params[1] / 2.0
+    Earg = distance * distance / kernel_params[0] / kernel_params[0] / kernel_params[1] / kernel_params[1gauss = exp(-Earg)
     gauss = exp(-Earg)
 
     return gauss * bessel

--- a/cygrid/kernels.pyx
+++ b/cygrid/kernels.pyx
@@ -191,7 +191,7 @@ cdef double gauss_bessel_kernel(
     arg = PI * fabs(distance) / kernel_params[0] / kernel_params[2]
     bessel = csc.j1(arg) / arg
 
-    Earg = distance * distance / kernel_params[0] / kernel_params[0] / kernel_params[1] / kernel_params[1gauss = exp(-Earg)
+    Earg = distance * distance / kernel_params[0] / kernel_params[0] / kernel_params[1] / kernel_params[1] / 2.0
     gauss = exp(-Earg)
 
     return gauss * bessel


### PR DESCRIPTION
The new definition of the Gauss-Bessel kernel is compatible with what gbtgridder is passing along in grid_otf.py.